### PR TITLE
Yogi patch 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# target files
+samples/src/sample[0-9]
+samples/src/sample1[0-9]
+samples/src/SampleCpuMonitoring

--- a/samples/src/SampleCpuMonitoring.c
+++ b/samples/src/SampleCpuMonitoring.c
@@ -21,7 +21,8 @@
 #define COL_MAIN_PAR	"COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=1;SAVE_COUNT=30;DATA_TYPE=double;"
 #define COL_SUB_PAR	"COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=10;SAVE_COUNT=30;DATA_TYPE=double;"
 
-#define REGISTER_TIME 30	/* サンプルデータの登録時間 10sec 以上を設定すること。 */
+#define REGISTER_TIME 10	/* サンプルデータの登録時間 10sec 以上を設定すること。 */
+#define SLEEP_INTERVAL (1)
 
 // バッファサイズ
 #define BUF		16
@@ -46,7 +47,7 @@ static void db_create_column(sdtsdb_t db, CID_PROCESSOR *cids, const int proc);
 static void db_aggregate_fixed_cycle(sdtsdb_t db, CID_PROCESSOR *cid);
 static int callback_func(sdntime_t ts, void *da, int dc, sdstat_t* st, int ret, void *user_data);
 static void db_insert(sdtsdb_t db, CID_PROCESSOR *cid, sdntime_t ts, const int proc, const double register_cpu);
-static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t *curr_ts);
+static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts);
 static void db_print_col_info(sdtsdb_t db, sdtscid_t cid, char *m, bool check);
 // VIEW
 static void view_table_header(const int view_proc_num);
@@ -57,14 +58,14 @@ static void ts2str(uint64_t ts, char *buff, size_t size);
 static int get_count_logical_processor(void);
 static int get_current_cpu_time(CPU time[]);
 static double calc_cpu_time(const CPU prev, const CPU curr);
-static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t *curr_ts);
+static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts);
 
 int main(int ac, char *av[]) {
 	sdtsdb_t db;
 	struct timespec current_ts;
 	timespec_get(&current_ts, TIME_UTC);
 	sdntime_t curr_ts = current_ts.tv_sec * 1000000000 + current_ts.tv_nsec;
-    char date[64];
+	char date[64];
 	strftime(date, sizeof(date), "%Y-%m-%d %a %H:%M:%S", localtime(&current_ts.tv_sec));
 	// printf("%ld.%09ld\n", current_ts.tv_sec, current_ts.tv_nsec);
 	printf("START : %s.%09ld\n", date, current_ts.tv_nsec);
@@ -86,9 +87,9 @@ int main(int ac, char *av[]) {
 	db_create_column(db, cids, processor);
 
 	// CPU使用率の計測と取得.
-	collect_cpu_load_data(db, cids, processor, &curr_ts);
+	collect_cpu_load_data(db, cids, processor, curr_ts);
 
-	show_cpu_time(db, cids, processor, &curr_ts);
+	show_cpu_time(db, cids, processor, curr_ts);
 
 	if (sdts_close_db(db) < 0) {
 		fprintf(stderr, "error sdts_close_db [%d]\n", sd_get_err());
@@ -143,7 +144,7 @@ static void db_aggregate_fixed_cycle(sdtsdb_t db, CID_PROCESSOR *cid) {
 	}
 }
 static int callback_func(sdntime_t ts, void *da, int dc, sdstat_t* st, int ret, void *user_data) {
-	CID_PROCESSOR *ana = (CID_PROCESSOR *)user_data;
+	CID_PROCESSOR *proc = (CID_PROCESSOR *)user_data;
 	if (st) {
 		/*printf("   sum[%f]sumsq[%f]min[%f]max[%f]mean[%f]\n \
 			var[%f]stdev[%f]uvar[%f]ustdev[%f]stder[%f]\n  \
@@ -162,9 +163,9 @@ static int callback_func(sdntime_t ts, void *da, int dc, sdstat_t* st, int ret, 
 		st->etime,	// window end time.
 		st->cnt);	// input count.*/
 
-		if (sdts_insert(ana->db, ana->max, st->etime, (char *) &st->max, 1) != 1) {
-			fprintf(stderr, "error sdts_insert [%d] : sdts_insert error in sdts_set_win callback: name[%s] \n", sd_get_err(), ana->name);
-			(void)sdts_close_db(ana->db);
+		if (sdts_insert(proc->db, proc->max, st->etime, (char *) &st->max, 1) != 1) {
+			fprintf(stderr, "error sdts_insert [%d] : sdts_insert error in sdts_set_win callback: name[%s] \n", sd_get_err(), proc->name);
+			(void)sdts_close_db(proc->db);
 			sd_end();
 			exit(EXIT_FAILURE);
 		}
@@ -185,28 +186,24 @@ static void db_insert(sdtsdb_t db, CID_PROCESSOR *cid, sdntime_t ts, const int p
 		exit(EXIT_FAILURE);
 	}
 }
-static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t *curr_ts) {
+static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t st) {
 	// データの取得
 	sdtscur_t cur;
 	const int col_type_num = 2;
 	const int ccnt = proc * col_type_num;
-	int i = 0, j = 0, ret = 0;
+	int ret = 0;
 	const sdntime_t iv = 1000000000;
-	sdntime_t ts;
-	sdntime_t st = *curr_ts;
 	sdntime_t et = st + iv * REGISTER_TIME;
 	sdtscid_t all_cids[proc * col_type_num];
 	sdtscurval_t val[proc * col_type_num];
 
-	for (i = 0; i < proc; i++) {
+	for (int i = 0; i < proc; i++) {
 		db_print_col_info(db, cids[i].act, "check act", false);// bool = true/false. true:colum info print.
 		db_print_col_info(db, cids[i].max, "check max", false);
-		all_cids[j] = cids[i].act;
-		all_cids[++j] = cids[i].max;
-		// printf("all_cids act:%d, max:%d\n", all_cids[j-1], all_cids[j]);
-		// printf("cids     act:%d, max:%d\n", cids[i].act, cids[i].max);
-		++j;
+		all_cids[2*i] = cids[i].act;
+		all_cids[2*i+1] = cids[i].max;
 	}
+
 	printf("all_cids : %ld\n", sizeof all_cids / sizeof all_cids[0]);
 	if ((cur = sdts_open_cur(db, all_cids, ccnt, st, et, iv, SDTS_CUR_OPT_AGGR_TS_PREV|SDTS_CUR_OPT_EXTEND)) < 0) {
 		fprintf(stderr, "error sdts_open_cur [%d]\n", sd_get_err());
@@ -216,25 +213,27 @@ static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdnt
 	const int view_proc_num = 4;
 	view_table_header(view_proc_num);
 
-	i = 0;
+	int cnt = 0;
 	while ((ret = sdts_fetch_cur(cur)) == SD_FETCH_OK) {
+		sdntime_t ts;
+
 		if (sdts_get_cur_aggr(cur, &ts, val, ccnt) < 0) {
-			fprintf(stderr, "error sdts_get_cur_aggr [%d][%d]\n", i, sd_get_err());
+			fprintf(stderr, "error sdts_get_cur_aggr [%d][%d]\n", cnt, sd_get_err());
 			sdts_close_cur(cur);
 			exit(EXIT_FAILURE);
 		}
-		view_table_record(ccnt, proc, i, ts, col_type_num, view_proc_num, val);
-		i++;
+		view_table_record(ccnt, proc, cnt, ts, col_type_num, view_proc_num, val);
+		cnt++;
 	}
 	view_table_footer(view_proc_num);
 
 	if (ret == SD_FETCH_ERR) {
-		fprintf(stderr, "error sdts_fetch_cur [%d][%d]\n", i, sd_get_err());
+		fprintf(stderr, "error sdts_fetch_cur [%d][%d]\n", cnt, sd_get_err());
 		sdts_close_cur(cur);
 		exit(EXIT_FAILURE);
 	}
 	if (sdts_close_cur(cur) < 0) {
-		fprintf(stderr, "error sdts_close_cur [%d][%d]\n", i, sd_get_err());
+		fprintf(stderr, "error sdts_close_cur [%d][%d]\n", cnt, sd_get_err());
 		exit(EXIT_FAILURE);
 	}
 }
@@ -341,6 +340,7 @@ static int get_current_cpu_time(CPU time[]){
 	if ( (fp=fopen(info,"r")) ==NULL) {
 		return 1;
 	}
+
 	char s[256];
 	int counter = 0;
 	while (fgets(s, sizeof s, fp) != NULL) {
@@ -370,24 +370,27 @@ static double calc_cpu_time(const CPU prev, const CPU curr) {
 		// printf("Active:%.1f%%\n", rateAct);
 		return (double)rateAct;
 }
-static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t *curr_ts) {
-	const int sleepSec = 1;
-	sdntime_t ts = *curr_ts;
-	printf("cpu logical processor count: %d\n", proc);
-	printf("Data acquisition time: %d sec\n", REGISTER_TIME);
+static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts) {
 	CPU prev_cpu_time[proc];
 	CPU current_cpu_time[proc];
-	double register_cpu;
 	int i, j;
 	int insert_count = 0, input_record = 0;
+
+	printf("cpu logical processor count: %d\n", proc);
+	printf("Data acquisition time: %d sec\n", REGISTER_TIME);
+
 	for (i = 0; i <= REGISTER_TIME; i++) {
 		// /proc/statからCPUの時刻を取得する.
 		get_current_cpu_time(current_cpu_time);
 		
 		if (i > 0) {
 			// 初回の取得はCPUの計算用のため2回目の取得から計測.
-			fprintf(stderr, "register count %d/%d\r", i, REGISTER_TIME);
+			printf("register count %d/%d\r", i, REGISTER_TIME);
+			fflush(stdout);
+
 			for (j = 0; j<proc; j++) {
+				double register_cpu;
+
 				register_cpu = calc_cpu_time(prev_cpu_time[j], current_cpu_time[j]);
 				db_insert(db, &cids[j], ts, proc, register_cpu);
 				insert_count++;
@@ -401,6 +404,6 @@ static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int pr
 		}
 		memcpy(prev_cpu_time, current_cpu_time, sizeof(current_cpu_time));
 		// Sleep 1 seconds.
-		sleep(sleepSec);
+		sleep(SLEEP_INTERVAL);
 	}
 }

--- a/samples/src/SampleCpuMonitoring.c
+++ b/samples/src/SampleCpuMonitoring.c
@@ -13,14 +13,6 @@
  * カラムタイプ MI データ登録 / カラムデータ取得
  */
 
-// [カラム定義]
-//   カラムタイプ Mi
-//   初期サンプリングレート 1Hz
-//   メモリ保存 30 件
-//   データサイズ 8バイト
-#define COL_MAIN_PAR "COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=1;SAVE_COUNT=30;DATA_TYPE=double;"
-#define COL_SUB_PAR "COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=10;SAVE_COUNT=30;DATA_TYPE=double;"
-
 #define REGISTER_TIME 30	/* サンプルデータの登録時間 10sec 以上を設定すること。 */
 #define SLEEP_INTERVAL (1)
 
@@ -29,47 +21,46 @@ typedef struct tag_cpu {
 	long act;
 } CPU;
 typedef struct tag_cid_processor {
-	const char *name;
-	sdtsdb_t db;
 	sdtscid_t act;
 	sdtscid_t max;
 } CID_PROCESSOR;
 
+/* Static function prototypes.  */
 // DB operation
-static void db_create_column(sdtsdb_t db, CID_PROCESSOR *cids, const int proc);
-static void db_aggregate_fixed_cycle(sdtsdb_t db, CID_PROCESSOR *cid);
+static void db_create_column(CID_PROCESSOR *cids, int proc);
+static void db_aggregate_fixed_cycle(CID_PROCESSOR *cid);
 static int callback_func(sdntime_t ts, void *da, int dc, sdstat_t* st, int ret, void *user_data);
-static void db_insert(sdtsdb_t db, CID_PROCESSOR *cid, sdntime_t ts, const int proc, const double register_cpu);
-static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts);
-static void db_print_col_info(sdtsdb_t db, sdtscid_t cid, char *m);
-// VIEW
-static void view_table_header(const int view_proc_num);
-static void view_table_footer(const int view_proc_num);
-static void view_table_record(const int ccnt, const int proc,  const int i, const sdntime_t ts, const int col_type_num, const int view_proc_num, sdtscurval_t *val);
-static void ts2str(uint64_t ts, char *buff, size_t size);
+static void db_insert(const CID_PROCESSOR *cid, sdntime_t ts, int proc, double register_cpu);
+static void show_cpu_time(const CID_PROCESSOR *cids, int proc, sdntime_t ts);
+static void db_print_col_info(sdtscid_t cid, const char *m);
+// result table printing.
+static void view_table_header(int view_proc_num);
+static void view_table_footer(int view_proc_num);
+static void view_table_record(int ccnt, int proc,  int i, sdntime_t ts, int col_type_num, int view_proc_num, const sdtscurval_t *val);
 // CPU operation
 static int get_count_logical_processor(void);
 static int get_current_cpu_time(CPU time[]);
-static double calc_cpu_time(const CPU prev, const CPU curr);
-static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts);
+static double calc_cpu_time(CPU prev, CPU curr);
+static void collect_cpu_load_data(const CID_PROCESSOR *cids, int proc, sdntime_t ts);
+// Others.
 static void abort_sample(void);
+static const char *ts2str(sdntime_t ts);
+static sdntime_t get_current_time(void);
+
+// Global variable.
+sdtsdb_t g_db = NULL;
+
 
 int main(void) {
-	sdtsdb_t db;
-	struct timespec current_ts;
-	timespec_get(&current_ts, TIME_UTC);
-	sdntime_t curr_ts = current_ts.tv_sec * 1000000000 + current_ts.tv_nsec;
-	char date[64];
-	strftime(date, sizeof(date), "%Y-%m-%d %a %H:%M:%S", localtime(&current_ts.tv_sec));
-	// printf("%ld.%09ld\n", current_ts.tv_sec, current_ts.tv_nsec);
-	printf("START : %s.%09ld\n", date, current_ts.tv_nsec);
+	sdntime_t curr_ts = get_current_time();
+	printf("START : %s\n", ts2str(curr_ts));
 
 	// DBライブラリの初期化＆DBオープン
 	if (sd_init(NULL) < 0) {
 		fprintf(stderr, "error sd_init [%d]\n", sd_get_err());
 		exit(EXIT_FAILURE);
 	}
-	if ((db = sdts_open_db(NULL)) == NULL) {
+	if ((g_db = sdts_open_db(NULL)) == NULL) {
 		fprintf(stderr, "error sdts_open_db [%d]\n", sd_get_err());
 		abort_sample();
 	}
@@ -77,16 +68,16 @@ int main(void) {
 	const int processor = get_count_logical_processor();
 	CID_PROCESSOR cids[processor];
 
-	db_create_column(db, cids, processor);
+	db_create_column(cids, processor);
 
 	// CPU使用率の計測と取得.
-	collect_cpu_load_data(db, cids, processor, curr_ts);
+	collect_cpu_load_data(cids, processor, curr_ts);
 
-	show_cpu_time(db, cids, processor, curr_ts);
+	show_cpu_time(cids, processor, curr_ts);
 
 
 	// DBクローズ＆DBライブラリの終了
-	if (sdts_close_db(db) < 0) {
+	if (sdts_close_db(g_db) < 0) {
 		fprintf(stderr, "error sdts_close_db [%d]\n", sd_get_err());
 		abort_sample();
 	}
@@ -95,67 +86,67 @@ int main(void) {
 		exit(EXIT_FAILURE);
 	}
 
-	timespec_get(&current_ts, TIME_UTC);
-	strftime(date, sizeof(date), "%Y-%m-%d %a %H:%M:%S", localtime(&current_ts.tv_sec));
-	printf("END : %s.%09ld\n", date, current_ts.tv_nsec);
-
+	printf("END : %s\n", ts2str(get_current_time()));
 	return 0;
 }
 
 // DB operation
-static void db_create_column(sdtsdb_t db, CID_PROCESSOR *cids, const int proc){
+static void db_create_column(CID_PROCESSOR *cids, int proc){
+	// [カラム定義]
+	//   カラムタイプ Mi
+	//   初期サンプリングレート 1Hz
+	//   メモリ保存 30 件
+	//   データサイズ 8バイト
+	const char *COL_MAIN_PAR = "COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=1;SAVE_COUNT=30;DATA_TYPE=double;";
+	const char *COL_SUB_PAR = "COL_TYPE=M;DATA_SIZE=8;SMPL_RATE=10;SAVE_COUNT=30;DATA_TYPE=double;";
 	char cidbuff[256];
+
 	for (int i = 0; i < proc; i++) {
-		cids[i].db = db;
-		cids[i].name = (char *)&i;
 		// CPUの論理プロセッサとCPU全体の使用率を格納するカラムを作成.
-		if ((cids[i].act = sdts_create_col(db, (sdid_t)&i, (char *)COL_MAIN_PAR)) < 0) {
+		if ((cids[i].act = sdts_create_col(g_db, (sdid_t)&i, (char *)COL_MAIN_PAR)) < 0) {
 			fprintf(stderr, "error sdts_create_col act [%d]\n", sd_get_err());
-			(void)sdts_close_db(db);
 			abort_sample();
 		}
 		
 		// 10秒ごとのWindow分析で、最大・最小・平均を格納するためのカラムを作成.
 		snprintf(cidbuff, 256, "%d_max", i);
-		if ((cids[i].max = sdts_create_col(db, (sdid_t)&cidbuff, (char *)COL_SUB_PAR)) < 0) {
+		if ((cids[i].max = sdts_create_col(g_db, (sdid_t)&cidbuff, (char *)COL_SUB_PAR)) < 0) {
 			fprintf(stderr, "error sdts_create_col max [%d]\n", sd_get_err());
-			(void)sdts_close_db(db);
 			abort_sample();
 		}
 
-		db_aggregate_fixed_cycle(db, &cids[i]);
+		db_aggregate_fixed_cycle(&cids[i]);
 	}
 }
-static void db_aggregate_fixed_cycle(sdtsdb_t db, CID_PROCESSOR *cid) {
-	if (sdts_set_win(db, cid->act, "window", SD_WT_COUNT, "WIN_COUNT=10;WIN_STAT=true;", callback_func, cid) < 0) {
+
+static void db_aggregate_fixed_cycle(CID_PROCESSOR *cid) {
+	if (sdts_set_win(g_db, cid->act, "window", SD_WT_COUNT, "WIN_COUNT=10;WIN_STAT=true;", callback_func, cid) < 0) {
 		fprintf(stderr, "error sdts_set_win [%d]\n", sd_get_err());
-		(void)sdts_close_db(db);
 		abort_sample();
 	}
 }
+
 static int callback_func(sdntime_t ts, void *da, int dc, sdstat_t* st, int ret, void *user_data) {
 	if (st) {
 		CID_PROCESSOR *proc = (CID_PROCESSOR *)user_data;
-		if (sdts_insert(proc->db, proc->max, st->etime, (char *) &st->max, 1) != 1) {
-			fprintf(stderr, "error sdts_insert [%d] : sdts_insert error in sdts_set_win callback: name[%s] \n", sd_get_err(), proc->name);
-			(void)sdts_close_db(proc->db);
+		if (sdts_insert(g_db, proc->max, st->etime, (char *) &st->max, 1) != 1) {
+			fprintf(stderr, "error sdts_insert [%d] : sdts_insert error in sdts_set_win callback:\n", sd_get_err());
 			abort_sample();
 		}
 	}
 
 	return 0;
 }
-static void db_insert(sdtsdb_t db, CID_PROCESSOR *cid, sdntime_t ts, const int proc, const double register_cpu) {
+static void db_insert(const CID_PROCESSOR *cid, sdntime_t ts, int proc, double register_cpu) {
 	// CPU使用率をDBに登録.
 	// タイムスタンプ設定 
 	// 0を指定した場合システム時間が初期タイムスタンプとなる。
-	if (sdts_insert(db, cid->act, ts, (char *) &register_cpu, 1) != 1) {
+	if (sdts_insert(g_db, cid->act, ts, (char *) &register_cpu, 1) != 1) {
 		fprintf(stderr, "error sdts_insert [%d]\n", sd_get_err());
-		(void)sdts_close_db(db);
 		abort_sample();
 	}
 }
-static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t st) {
+static void show_cpu_time(const CID_PROCESSOR *cids, int proc, sdntime_t st) {
 	// データの取得
 	sdtscur_t cur;
 	const int col_type_num = 2;
@@ -167,14 +158,14 @@ static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdnt
 	sdtscurval_t val[proc * col_type_num];
 
 	for (int i = 0; i < proc; i++) {
-		db_print_col_info(db, cids[i].act, "check act");// bool = true/false. true:colum info print.
-		db_print_col_info(db, cids[i].max, "check max");
+		db_print_col_info(cids[i].act, "check act");// bool = true/false. true:colum info print.
+		db_print_col_info(cids[i].max, "check max");
 		all_cids[2*i] = cids[i].act;
 		all_cids[2*i+1] = cids[i].max;
 	}
 
 	printf("all_cids : %ld\n", sizeof all_cids / sizeof all_cids[0]);
-	if ((cur = sdts_open_cur(db, all_cids, ccnt, st, et, iv, SDTS_CUR_OPT_AGGR_TS_PREV|SDTS_CUR_OPT_EXTEND)) < 0) {
+	if ((cur = sdts_open_cur(g_db, all_cids, ccnt, st, et, iv, SDTS_CUR_OPT_AGGR_TS_PREV|SDTS_CUR_OPT_EXTEND)) < 0) {
 		fprintf(stderr, "error sdts_open_cur [%d]\n", sd_get_err());
 		abort_sample();
 	}
@@ -206,11 +197,11 @@ static void show_cpu_time(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdnt
 		abort_sample();
 	}
 }
-static void db_print_col_info(sdtsdb_t db, sdtscid_t cid, char *m) {
+static void db_print_col_info(sdtscid_t cid, const char *m) {
 #if DEBUG
 	sdtscolinfo_t *ip;
 
-	if ((ip = sdts_get_col_info(db, cid)) == NULL) {
+	if ((ip = sdts_get_col_info(g_db, cid)) == NULL) {
 		fprintf(stderr, "error sdts_get_col_info [%d]\n", sd_get_err());
 		abort_sample();
 	}
@@ -233,9 +224,9 @@ static void db_print_col_info(sdtsdb_t db, sdtscid_t cid, char *m) {
 #endif
 }
 // VIEW
-static void view_table_header(const int view_proc_num){
-
+static void view_table_header(int view_proc_num){
 	/* print following header lines.
+	 *
 	 *   |----|----------------------------|---------------|---------------|---------------|---------------|
 	 *   | No | ts                         | Total         | processor(1)  | processor(2)  | processor(3)  |
 	 *   |    |                            |---------------|---------------|---------------|---------------|
@@ -255,16 +246,14 @@ static void view_table_header(const int view_proc_num){
 	for (i=0; i < view_proc_num; i++) printf("---------------|");
 }
 
-static void view_table_record(const int ccnt, const int proc,  const int i, const sdntime_t ts, const int col_type_num, const int view_proc_num, sdtscurval_t *val){
+static void view_table_record(int ccnt, int proc,  int i, sdntime_t ts, int col_type_num, int view_proc_num, const sdtscurval_t *val){
 	/* print following data lines.
+	 *
 	 *   |0001|ts[20-07-07T22:32:16.120563]|  7.8% |       |  8.0% |       |  5.1% |       |  9.9% |       |
 	 *   |0002|ts[20-07-07T22:32:17.120563]|  6.8% |       |  7.9% |       |  6.9% |       |  4.0% |       |
 	 *   |0003|ts[20-07-07T22:32:18.120563]|  4.7% |       |  5.9% |       |  2.9% |       |  5.0% |       |
 	 */
-	char buff[64];
-
-	ts2str(ts, buff, sizeof(buff));
-	printf("\n|%04d|ts[%11s]|", i + 1, buff);
+	printf("\n|%04d|ts[%11s]|", i + 1, ts2str(ts));
 
 	for (int j = 0; j < ccnt; j++) {
 		if ((j / col_type_num) >= view_proc_num) continue; // 表示しないプロセッサはスキップ
@@ -277,7 +266,7 @@ static void view_table_record(const int ccnt, const int proc,  const int i, cons
 		}
 	}
 }
-static void view_table_footer(const int view_proc_num){
+static void view_table_footer(int view_proc_num){
 	/* print following footer line.
 	 * 
 	 *   |----|----------------------------|---------------|---------------|---------------|---------------|
@@ -287,21 +276,6 @@ static void view_table_footer(const int view_proc_num){
 	printf("\n\n");
 }
 
-static void ts2str(uint64_t ts, char *buff, size_t size){
-	struct tm *cal;
-
-	time_t t = ts / (1000*1000*1000);
-	cal = localtime(&t);
-
-	snprintf(buff, size, "%02d-%02d-%02dT%02d:%02d:%02d.%06ld",
-		(cal->tm_year+1900) % 100,
-		cal->tm_mon+1,
-		cal->tm_mday,
-		cal->tm_hour,
-		cal->tm_min,
-		cal->tm_sec,
-		(ts/1000) % 1000000);
-}
 // CPU operation
 static int get_count_logical_processor(){
 	FILE	*fp;
@@ -344,12 +318,12 @@ static int get_current_cpu_time(CPU time[]){
 	fclose(fp);
 	return 0;
 }
-static double calc_cpu_time(const CPU prev, const CPU curr) {
+static double calc_cpu_time(CPU prev, CPU curr) {
 	double diffTotal = curr.total - prev.total;
 	double diffAct = curr.act - prev.act;
 	return diffAct * 100 / (double) diffTotal;
 }
-static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int proc, sdntime_t ts) {
+static void collect_cpu_load_data(const CID_PROCESSOR *cids, int proc, sdntime_t ts) {
 	CPU prev_cpu_time[proc];
 	CPU current_cpu_time[proc];
 
@@ -368,7 +342,7 @@ static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int pr
 
 		for (int j = 0; j<proc; j++) {
 			double cpuLoad = calc_cpu_time(prev_cpu_time[j], current_cpu_time[j]);
-			db_insert(db, &cids[j], ts, proc, cpuLoad);
+			db_insert(&cids[j], ts, proc, cpuLoad);
 		}
 
 		// 初回以降、登録時のタイムスタンプが 0 である場合、
@@ -381,7 +355,47 @@ static void collect_cpu_load_data(sdtsdb_t db, CID_PROCESSOR *cids, const int pr
 	}
 }
 
+static sdntime_t get_current_time(void) {
+#if 1
+	struct timespec ts;
+	timespec_get(&ts, TIME_UTC);
+	return ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+#else
+	sdntime_t retval = 0;
+	struct timespec ts;
+	int err = clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+	if (err < 0) {
+		perror("clock_gettime");
+		exit(EXIT_FAILURE);
+	} else {
+		retval = ( ts.tv_sec * 1000000000ULL ) + ( ts.tv_nsec );
+	}
+	return retval;
+#endif
+}
+static const char *ts2str(sdntime_t ts) {
+	static char buff[64];
+	struct tm *cal;
+
+	time_t t = ts / (1000*1000*1000);
+	cal = localtime(&t);
+
+	snprintf(buff, 64, "%02d-%02d-%02dT%02d:%02d:%02d.%06lld",
+		cal->tm_year-100,
+		cal->tm_mon+1,
+		cal->tm_mday,
+		cal->tm_hour,
+		cal->tm_min,
+		cal->tm_sec,
+		(ts/1000) % 1000000);
+
+	return buff;
+}
+
 static void abort_sample(void) {
+	if (g_db) {
+		(void)sdts_close_db(g_db);
+	}
 	sd_end();
 	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
* .gitignore整理
* 構造体の不要フィールドを削除
* 関数引数の不要なconst修飾子を除去
* 参照先を変更しない関数引数のポインタにconst修飾子を追加
* 時刻文字列生成処理を整理
* db変数をグローバル化
* 異常終了処理を関数化
* 不要なコメントを除去
* ループ内の初回限定処理を切り出し
